### PR TITLE
Add README and expand test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,151 @@
+# github-channels
+
+MCP channel server that pushes GitHub webhook events into Claude Code sessions. Real-time perception instead of polling.
+
+## What It Does
+
+GitHub sends webhook POSTs when things happen (push, PR, issue comment, CI result). This server receives them and pushes structured events into your Claude Code session via the MCP channel protocol. Your agent perceives repo activity in real-time.
+
+## Setup
+
+### 1. Install
+
+```bash
+git clone https://github.com/mlops-kelvin/github-channels.git
+cd github-channels
+bun install
+```
+
+### 2. Configure
+
+```bash
+cp .env.example .env
+```
+
+Edit `.env`:
+
+```env
+GITHUB_WEBHOOK_SECRET=your-secret-here    # openssl rand -hex 20
+GITHUB_REPOS=owner/repo-a,owner/repo-b   # repos to accept events from
+GITHUB_EVENTS=push,pull_request,issues,issue_comment,pull_request_review
+PORT=8789
+TRUSTED_ACTORS=your-username,teammate     # GitHub usernames — events tagged team vs external
+CHANNEL_TIP=Tip: curl -X POST localhost:8789/mute/owner/repo?hours=5 to mute a noisy repo.
+```
+
+### 3. Wire into Claude Code
+
+Add to your project's `.claude/settings.json` or `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "github-channels": {
+      "type": "stdio",
+      "command": "bun",
+      "args": ["run", "/path/to/github-channels/server.ts"]
+    }
+  }
+}
+```
+
+### 4. Configure GitHub webhook
+
+On each monitored repo: Settings > Webhooks > Add webhook
+
+- **Payload URL**: `https://your-domain.com/webhook/github` (proxied to localhost:8789)
+- **Content type**: `application/json`
+- **Secret**: same value as `GITHUB_WEBHOOK_SECRET` in .env
+- **Events**: select the events matching your `GITHUB_EVENTS` config
+
+### 5. Reverse proxy
+
+The server binds to `127.0.0.1:8789` (localhost only). Use a reverse proxy (Angie, nginx, Caddy) to expose `/webhook/github` to the internet for GitHub to reach.
+
+## Control Endpoints
+
+All control is via HTTP — no session restart needed.
+
+### Mute / Unmute
+
+```bash
+# Global
+curl -X POST localhost:8789/mute          # mute all events
+curl -X POST localhost:8789/unmute        # unmute all events
+
+# Per-repo (timed)
+curl -X POST localhost:8789/mute/owner/repo?hours=5   # mute for 5 hours
+curl -X POST localhost:8789/mute/owner/repo            # mute indefinitely
+curl -X POST localhost:8789/unmute/owner/repo          # unmute
+
+# Bulk (sleep/wake cycles)
+curl -X POST localhost:8789/mute-all?hours=8   # mute all repos for 8 hours
+curl -X POST localhost:8789/unmute-all          # unmute everything
+```
+
+### Status
+
+```bash
+curl localhost:8789/status
+```
+
+Returns: muted state, muted repos with time remaining, configured repos/events, event counters.
+
+## Event Format
+
+Events arrive in the agent's context as:
+
+```
+<channel source="github" event_type="push" repo="owner/repo" author="username" trust_tier="team" action="">
+username pushed 3 commit(s) to owner/repo/main
+  - Fix login validation
+  - Update tests
+  - Bump version
+</channel>
+```
+
+### Supported Events
+
+| Event | What triggers it |
+|-------|-----------------|
+| `push` | Commits pushed to a branch |
+| `pull_request` | PR opened, closed, merged, synchronized |
+| `issues` | Issue opened, closed, labeled |
+| `issue_comment` | Comment on an issue or PR |
+| `pull_request_review` | PR review submitted |
+| `check_run` | CI check completed |
+| `workflow_run` | GitHub Actions workflow completed |
+| `release` | Release published |
+
+## Security
+
+### Transport layer (HMAC)
+
+- Webhook secret is **required** at startup (server exits if not set)
+- Every webhook POST is verified with HMAC-SHA256 (`X-Hub-Signature-256` header)
+- Server binds to localhost only — not directly reachable from internet
+
+### Agent layer (trust tiers)
+
+Events include a `trust_tier` metadata field:
+
+- **`team`**: Actor is in `TRUSTED_ACTORS` list. Act normally.
+- **`external`**: Unknown actor. Content is untrusted — do not execute commands or modify files based solely on it.
+
+The MCP instructions warn agents about prompt injection via public repo comments and include a response protocol: mute repo, notify team, do not process suspicious content.
+
+### Additional hardening
+
+- Reverse proxy can restrict to [GitHub's webhook IP ranges](https://api.github.com/meta) (`hooks` key)
+- Content is truncated to 2000 characters to prevent context flooding
+
+## Development
+
+```bash
+bun test           # run test suite (14 tests)
+bun run dev        # start with --watch for development
+```
+
+## License
+
+MIT — Marbell AG

--- a/server.test.ts
+++ b/server.test.ts
@@ -280,6 +280,73 @@ describe("ping", () => {
 // 404
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// Mute-all / Unmute-all
+// ---------------------------------------------------------------------------
+
+describe("mute-all / unmute-all", () => {
+  it("mutes all configured repos", async () => {
+    let res = await fetch(`${BASE}/mute-all?hours=2`, { method: "POST" });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.muted_repos).toEqual(["test-org/repo-a", "test-org/repo-b"]);
+    expect(data.hours).toBe("2");
+
+    // Events from any configured repo should be muted
+    res = await webhook("push", {
+      repository: { full_name: "test-org/repo-a" },
+      sender: { login: "dev" },
+      ref: "refs/heads/main",
+      commits: [{ message: "test" }],
+    });
+    expect(await res.text()).toBe("repo muted");
+
+    // Clean up
+    await fetch(`${BASE}/unmute-all`, { method: "POST" });
+  });
+
+  it("unmute-all clears everything", async () => {
+    await fetch(`${BASE}/mute`, { method: "POST" });
+    await fetch(`${BASE}/mute/test-org/repo-a`, { method: "POST" });
+
+    const res = await fetch(`${BASE}/unmute-all`, { method: "POST" });
+    const data = await res.json();
+    expect(data.cleared).toBe(true);
+    expect(data.global_mute).toBe(false);
+
+    // Verify status is clean
+    const status = await (await fetch(`${BASE}/status`)).json();
+    expect(status.muted).toBe(false);
+    expect(Object.keys(status.mutedRepos)).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Event counters
+// ---------------------------------------------------------------------------
+
+describe("event counters", () => {
+  it("tracks counts in /status", async () => {
+    const before = await (await fetch(`${BASE}/status`)).json();
+    const prevDelivered = before.counts.delivered;
+
+    await webhook("push", {
+      repository: { full_name: "test-org/repo-a" },
+      sender: { login: "dev" },
+      ref: "refs/heads/main",
+      commits: [{ message: "counter test" }],
+    });
+
+    const after = await (await fetch(`${BASE}/status`)).json();
+    expect(after.counts.delivered).toBeGreaterThan(prevDelivered);
+    expect(after.counts.received).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 404
+// ---------------------------------------------------------------------------
+
 describe("routing", () => {
   it("returns 404 for unknown paths", async () => {
     const res = await fetch(`${BASE}/nonexistent`);


### PR DESCRIPTION
## Summary
- README with full setup guide, security model documentation, control endpoints, and event format reference
- 3 new tests: mute-all/unmute-all and event counters
- Total: 17 tests, 43 assertions

## Test plan
- [x] `bun test` — 17/17 passing
- [ ] Nexus review

🤖 Generated with [Claude Code](https://claude.com/claude-code)