### PR TITLE
fix: add marketplace.json for plugin discovery

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "github-channels",
+  "description": "GitHub webhook channel for Claude Code — real-time push, PR, issue, and CI events streamed into your session",
+  "owner": {
+    "name": "mlops-kelvin",
+    "url": "https://github.com/mlops-kelvin"
+  },
+  "plugins": [
+    {
+      "name": "github-channels",
+      "description": "GitHub webhook channel for Claude Code — real-time push, PR, issue, and CI events streamed into your session with trust tiers and mute controls.",
+      "source": ".",
+      "category": "productivity",
+      "homepage": "https://github.com/mlops-kelvin/github-channels"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -5,10 +5,14 @@ Claude Code plugin that streams GitHub webhook events into your session in real-
 ## Install
 
 ```bash
-claude plugins add mlops-kelvin/github-channels
+# Add the marketplace (one-time)
+claude plugins marketplace add mlops-kelvin/github-channels
+
+# Install the plugin
+claude plugins install github-channels
 ```
 
-That's it. The plugin registers its MCP server automatically. On first run, it:
+Restart Claude Code after installing. The plugin registers its MCP server automatically. On first run, it:
 - Creates a config template at `~/.claude/channels/github-channels/config.json`
 - Auto-generates a webhook secret at `~/.github-channels-secret`
 


### PR DESCRIPTION
## Summary
- Adds `.claude-plugin/marketplace.json` so the repo works as a self-contained marketplace
- Fixes README install command (`plugins install`, not `plugins add`) and adds marketplace registration step

Without `marketplace.json`, `claude plugins marketplace add mlops-kelvin/github-channels` fails with "Marketplace file not found".

## Test plan
- [ ] `claude plugins marketplace add mlops-kelvin/github-channels` succeeds
- [ ] `claude plugins install github-channels` installs the plugin
- [ ] Restart Claude Code → plugin loads, MCP server starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)