### PR TITLE
fix: marketplace.json schema validation errors

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,5 @@
 {
-  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "github-channels",
-  "description": "GitHub webhook channel for Claude Code — real-time push, PR, issue, and CI events streamed into your session",
   "owner": {
     "name": "mlops-kelvin",
     "url": "https://github.com/mlops-kelvin"
@@ -10,7 +8,7 @@
     {
       "name": "github-channels",
       "description": "GitHub webhook channel for Claude Code — real-time push, PR, issue, and CI events streamed into your session with trust tiers and mute controls.",
-      "source": ".",
+      "source": "./",
       "category": "productivity",
       "homepage": "https://github.com/mlops-kelvin/github-channels"
     }


### PR DESCRIPTION
## Summary
Fixes marketplace.json that was merged in PR #17 but had validation errors:
- Removes `$schema` and `description` root keys (unrecognized by Claude Code validator)
- Changes `source` from `"."` to `"./"` (validator rejects bare dot)

Validated locally: `claude plugins validate .` passes.

## Test plan
- [ ] `claude plugins validate .` passes
- [ ] `claude plugins marketplace add mlops-kelvin/github-channels` succeeds
- [ ] `claude plugins install github-channels` installs the plugin

🤖 Generated with [Claude Code](https://claude.com/claude-code)